### PR TITLE
V1.3

### DIFF
--- a/AiracGen.Debugger/AiracGen.Debugger.csproj
+++ b/AiracGen.Debugger/AiracGen.Debugger.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AiracGen\AiracGen.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/AiracGen.Debugger/Program.cs
+++ b/AiracGen.Debugger/Program.cs
@@ -1,0 +1,3 @@
+﻿using AiracGen;
+
+_ = AiracGenerator.GenerateByYear(2021);

--- a/AiracGen.Debugger/Program.cs
+++ b/AiracGen.Debugger/Program.cs
@@ -1,3 +1,3 @@
 ﻿using AiracGen;
 
-_ = AiracGenerator.GenerateByYear(2021);
+var year = AiracGenerator.GenerateByYear(2020);

--- a/AiracGen.sln
+++ b/AiracGen.sln
@@ -5,7 +5,9 @@ VisualStudioVersion = 17.7.34031.279
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AiracGenCLI", "AiracGenCLI\AiracGenCLI.csproj", "{81D9B1F3-754C-4240-A9C0-C4B2CCFAAAF6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AiracGen", "AiracGen\AiracGen.csproj", "{581B0ACD-C794-4D70-9400-21E4BC237646}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AiracGen", "AiracGen\AiracGen.csproj", "{581B0ACD-C794-4D70-9400-21E4BC237646}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AiracGen.Debugger", "AiracGen.Debugger\AiracGen.Debugger.csproj", "{26AA08BA-B609-40E8-A257-0BC2D3B1DC0E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{581B0ACD-C794-4D70-9400-21E4BC237646}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{581B0ACD-C794-4D70-9400-21E4BC237646}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{581B0ACD-C794-4D70-9400-21E4BC237646}.Release|Any CPU.Build.0 = Release|Any CPU
+		{26AA08BA-B609-40E8-A257-0BC2D3B1DC0E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{26AA08BA-B609-40E8-A257-0BC2D3B1DC0E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{26AA08BA-B609-40E8-A257-0BC2D3B1DC0E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{26AA08BA-B609-40E8-A257-0BC2D3B1DC0E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/AiracGen/AiracGen.csproj
+++ b/AiracGen/AiracGen.csproj
@@ -8,8 +8,8 @@
     <Title>AiracGen</Title>
     <Authors>Tim Unger</Authors>
     <Company>Tim Unger</Company>
-    <FileVersion>1.1</FileVersion>
-    <Version>1.1</Version>
+    <FileVersion>1.2</FileVersion>
+    <Version>1.2</Version>
   </PropertyGroup>
 
 </Project>

--- a/AiracGen/AiracGenerator.cs
+++ b/AiracGen/AiracGenerator.cs
@@ -82,7 +82,7 @@ namespace AiracGen
 
         /// <summary>
         /// Gets all Airacs between the given years (inclusive of the provided years)
-        /// Squashed as List<Airac>
+        /// Squashed into a single List<Airac> with all Airacs
         /// </summary>
         /// <param name="startYear">The Start-Year</param>
         /// <param name="endYear">The End-Year</param>
@@ -91,14 +91,27 @@ namespace AiracGen
 
         /// <summary>
         /// Gets all Airacs between the given years (inclusive of the provided years)
+        /// The Airacs are sorted into sublists of the respective year
         /// </summary>
         /// <param name="startYear">The Start-Year</param>
         /// <param name="endYear">The End-Year</param>
         /// <returns></returns>
         public static List<List<Airac>> GenerateBetweenYearsSorted(int startYear, int endYear) => BetweenYears.GenerateSorted(startYear, endYear);
 
+        /// <summary>
+        /// Gets all Airacs of the given years
+        /// Squashed into a single List<Airac> with all Airacs
+        /// </summary>
+        /// <param name="years">the respective years</param>
+        /// <returns></returns>
         public static List<Airac> GenerateForYearsUnsorted(params int[] years) => ForYears.GenerateUnsorted(years);
 
+        /// <summary>
+        /// Gets all Airacs of the given years
+        /// The Airacs are sorted into sublists of the respective year
+        /// </summary>
+        /// <param name="years">the respective years</param>
+        /// <returns></returns>
         public static List<List<Airac>> GenerateForYearsSorted(params int[] years) => ForYears.GenerateSorted(years);
     }
 }

--- a/AiracGen/AiracGenerator.cs
+++ b/AiracGen/AiracGenerator.cs
@@ -76,8 +76,29 @@ namespace AiracGen
         /// Get all Airacs in the provided year
         /// If you only provide two chars (e.g. 23) the program assums that you mean the current century (=> 2023)
         /// </summary>
-        /// <param name="year"></param>
+        /// <param name="year">the year you want to get the Airacs of</param>
         /// <returns></returns>
         public static List<Airac> GenerateByYear(int year) => ByYear.Generate(year);
+
+        /// <summary>
+        /// Gets all Airacs between the given years (inclusive of the provided years)
+        /// Squashed as List<Airac>
+        /// </summary>
+        /// <param name="startYear">The Start-Year</param>
+        /// <param name="endYear">The End-Year</param>
+        /// <returns></returns>
+        public static List<Airac> GenerateBetweenYears(int startYear, int endYear) => BetweenYears.GenerateUnsorted(startYear, endYear);
+
+        /// <summary>
+        /// Gets all Airacs between the given years (inclusive of the provided years)
+        /// </summary>
+        /// <param name="startYear">The Start-Year</param>
+        /// <param name="endYear">The End-Year</param>
+        /// <returns></returns>
+        public static List<List<Airac>> GenerateBetweenYearsSorted(int startYear, int endYear) => BetweenYears.GenerateSorted(startYear, endYear);
+
+        public static List<Airac> GenerateForYearsUnsorted(params int[] years) => ForYears.GenerateUnsorted(years);
+
+        public static List<List<Airac>> GenerateForYearsSorted(params int[] years) => ForYears.GenerateSorted(years);
     }
 }

--- a/AiracGen/Generator/GenerateBetweenYears.cs
+++ b/AiracGen/Generator/GenerateBetweenYears.cs
@@ -1,0 +1,30 @@
+﻿namespace AiracGen.Generator
+{
+    internal class BetweenYears
+    {
+        internal static List<Airac> GenerateUnsorted(int startYear, int endYear) => (List<Airac>)Generate(startYear, endYear, true);
+        internal static List<List<Airac>> GenerateSorted(int startYear, int endYear) => (List<List<Airac>>)Generate(startYear, endYear, false);
+       
+
+        private static object Generate(int startYear, int endYear, bool shouldBeSquashed)
+        {
+            var airacs = new List<Airac>();
+
+            var years = new List<int>();
+
+            var currentYear = startYear;
+            for (var i = startYear; i <= endYear; i++)
+            {
+                years.Add(currentYear);
+                currentYear++;
+            }
+
+            if (shouldBeSquashed)
+            {
+                return years.Select(ByYear.Generate).ToList().SelectMany(x => x).ToList();
+            }
+
+            return years.Select(ByYear.Generate).ToList();
+        }
+    }
+}

--- a/AiracGen/Generator/GenerateByYear.cs
+++ b/AiracGen/Generator/GenerateByYear.cs
@@ -12,7 +12,7 @@
 
             if(year.ToString().Length != 4)
             {
-                throw new Exception("Year was not a valid year");
+                throw new Exception($"Year {year} was not a valid year");
             }
 
             var maxAmountOfCyclesInYear = 0;

--- a/AiracGen/Generator/GenerateByYear.cs
+++ b/AiracGen/Generator/GenerateByYear.cs
@@ -45,6 +45,7 @@
                 identList.Add(ident);
             }
 
+            //We now have every possible Ident in the provided year, so we can create an Airac of every Ident
             return identList.Select(AiracGenerator.GenerateSingle).ToList();
         }
     }

--- a/AiracGen/Generator/GenerateForYears.cs
+++ b/AiracGen/Generator/GenerateForYears.cs
@@ -1,0 +1,9 @@
+﻿namespace AiracGen.Generator
+{
+    internal class ForYears
+    {
+        internal static List<Airac> GenerateUnsorted(params int[] years) => years.Select(ByYear.Generate).SelectMany(x => x).ToList();
+
+        internal static List<List<Airac>> GenerateSorted(params int[] years) => years.Select(ByYear.Generate).ToList();
+    }
+}

--- a/AiracGen/Generator/GeneratePast.cs
+++ b/AiracGen/Generator/GeneratePast.cs
@@ -47,6 +47,8 @@ namespace AiracGen.Generator
                 airacs.Add(airac);
             }
 
+            airacs = airacs.OrderBy(x => x.StartDate).ToList();
+
             //Checks that everything got generated correctly
             if (!airacs.AreAllValuesCorrect())
             {

--- a/AiracGen/Generator/GenerateSingle.cs
+++ b/AiracGen/Generator/GenerateSingle.cs
@@ -17,6 +17,8 @@
             //We have to subtract the smaller number, so if the ident year is larger we have to subtract the current year, if not we have to subtract the ident year
             var yearAmount = currentYear <= identYear ? identYear - currentYear : currentYear - identYear;
 
+            yearAmount++;
+
             //Provided year is the current year
             if(yearAmount == 0)
             {

--- a/AiracGen/Generator/GenerateSingle.cs
+++ b/AiracGen/Generator/GenerateSingle.cs
@@ -29,7 +29,7 @@
             var airacs = AiracGenerator.GeneratePastAndFuture(15 * yearAmount, 15 * yearAmount);
 
             return airacs.FirstOrDefault(x => x.Ident == ident)
-                ?? throw new Exception("Ident not found");
+                ?? throw new Exception($"Ident {ident} not found");
         }
     }
 }


### PR DESCRIPTION
- Fixed bug with GenerateForYear()
- Added GenerateBetweenYearsSorted() and GenerateBetweenYearsUnsorted()
     -  Will generate Airacs between the given years (inclusive of the provided years)
 - Added GenerateForYearsSorted() and GenerateForYearsUnsorted()
     -  Will generate Airacs for the given years (as many as you provide)
- Sorted() will sort them into sublists List<List<Airac>>() of each year
 - Unsorted() will put them all into one List<Airac> 
 - Small fixes to Exception Messages